### PR TITLE
Add cost estimation fields and logic

### DIFF
--- a/estimate_form_instructions.txt
+++ b/estimate_form_instructions.txt
@@ -1,0 +1,29 @@
+Estimate Form Implementation Instructions
+
+1. Add car rate input: Provide a dropdown list of car types with fixed rates.
+   - Luxury Sedan: INR 2000
+   - Sports Car: INR 5000
+   - SUV: INR 3000
+   - The selected rate contributes to the estimate.
+
+2. Add decoration type selection with cost:
+   - Fresh decoration: INR 1000
+   - Artificial decoration: INR 500
+   - Cost applies only when decoration is requested.
+
+3. Travel distance calculation:
+   - Input total distance in kilometers.
+   - Each kilometer adds INR 30 to the estimate.
+
+4. Hourly cost for duration:
+   - Input total booking duration in hours.
+   - Base rate: INR 800 for up to 8 hours.
+   - Additional INR 100 for each hour beyond 8.
+
+5. Estimate calculation:
+   - Total = Car Rate + Decoration Cost + (Distance × 30) + Hourly Charges.
+   - Update and display the total in real time as inputs change.
+
+6. Display the estimate on the form for user review before submission.
+
+7. Test to ensure each input updates the total correctly.

--- a/index.html
+++ b/index.html
@@ -294,6 +294,12 @@
             font-size: 0.9rem;
         }
 
+        .estimate-output {
+            margin-top: 10px;
+            font-size: 1.2rem;
+            color: #FFD700;
+        }
+
         .instagram-link {
             display: inline-block;
             margin-top: 15px;
@@ -664,12 +670,12 @@
                             <span class="decor-label">Decoration Type</span>
                             <fieldset class="segmented small" role="radiogroup" aria-label="Decoration type">
                                 <label class="seg-item">
-                                    <input type="radio" name="decorationTypeRadio" value="Artificial Flowers">
-                                    <span>Artificial Flowers</span>
+                                    <input type="radio" name="decorationTypeRadio" value="Artificial">
+                                    <span>Artificial (INR 500)</span>
                                 </label>
                                 <label class="seg-item">
-                                    <input type="radio" name="decorationTypeRadio" value="Fresh Flowers">
-                                    <span>Fresh Flowers</span>
+                                    <input type="radio" name="decorationTypeRadio" value="Fresh">
+                                    <span>Fresh (INR 1000)</span>
                                 </label>
                             </fieldset>
                         </div>
@@ -682,7 +688,17 @@
 
             <div class="form-section">
                 <h2 class="section-title"><i class="fas fa-car"></i> Vehicle Selection</h2>
-                
+
+                <div class="form-group">
+                    <label for="carType">Car Type:</label>
+                    <select id="carType" name="carType">
+                        <option value="">Select car type...</option>
+                        <option value="Luxury Sedan">Luxury Sedan - INR 2000</option>
+                        <option value="Sports Car">Sports Car - INR 5000</option>
+                        <option value="SUV">SUV - INR 3000</option>
+                    </select>
+                </div>
+
                 <div class="form-group">
                     <label for="vehicle">Select Your Vehicle:</label>
                     <select id="vehicle" name="vehicle" required>
@@ -718,6 +734,21 @@
                         <div class="hour-option" data-hours="48">2 Days</div>
                     </div>
                     <input type="hidden" id="eventHours" name="eventHours" value="">
+                </div>
+            </div>
+
+            <div class="form-section">
+                <h2 class="section-title"><i class="fas fa-route"></i> Travel Details</h2>
+                <div class="form-group">
+                    <label for="distance">Travel Distance (km):</label>
+                    <input type="number" id="distance" name="distance" min="0" placeholder="Enter distance">
+                </div>
+                <div class="form-group">
+                    <label for="duration">Booking Duration (hours):</label>
+                    <input type="number" id="duration" name="duration" min="0" placeholder="Enter total hours">
+                </div>
+                <div class="estimate-output">
+                    <strong>Total Estimate: INR <span id="totalEstimate">0</span></strong>
                 </div>
             </div>
 
@@ -1153,9 +1184,10 @@
                 } else {
                     decorationOptions.classList.remove('show');
                 }
-                
+
                 // Update hidden field
                 document.getElementById('wantDecoration').value = this.value;
+                calculateEstimate();
             });
         });
 
@@ -1163,8 +1195,57 @@
         document.querySelectorAll('input[name="decorationTypeRadio"]').forEach(radio => {
             radio.addEventListener('change', function() {
                 document.getElementById('decoration').value = this.value;
+                calculateEstimate();
             });
         });
+        const CAR_RATES = {
+            'Luxury Sedan': 2000,
+            'Sports Car': 5000,
+            'SUV': 3000
+        };
+
+        const DECORATION_COSTS = {
+            'Fresh': 1000,
+            'Artificial': 500
+        };
+
+        function calculateEstimate() {
+            const carType = document.getElementById('carType')?.value;
+            const carRate = CAR_RATES[carType] || 0;
+
+            const wantDecoration = document.querySelector('input[name="wantDecorationRadio"]:checked')?.value;
+            let decorationCost = 0;
+            if (wantDecoration === 'Yes') {
+                const decoType = document.querySelector('input[name="decorationTypeRadio"]:checked')?.value;
+                decorationCost = DECORATION_COSTS[decoType] || 0;
+            }
+
+            const distance = parseFloat(document.getElementById('distance')?.value) || 0;
+            const distanceCost = distance * 30;
+
+            const duration = parseFloat(document.getElementById('duration')?.value) || 0;
+            let hourlyCost = 0;
+            if (duration > 0) {
+                hourlyCost = 800;
+                if (duration > 8) {
+                    hourlyCost += (duration - 8) * 100;
+                }
+            }
+
+            const total = carRate + decorationCost + distanceCost + hourlyCost;
+            const estimateEl = document.getElementById('totalEstimate');
+            if (estimateEl) {
+                estimateEl.textContent = total;
+            }
+        }
+
+        const carTypeEl = document.getElementById('carType');
+        if (carTypeEl) carTypeEl.addEventListener('change', calculateEstimate);
+        ['distance', 'duration'].forEach(id => {
+            const el = document.getElementById(id);
+            if (el) el.addEventListener('input', calculateEstimate);
+        });
+        calculateEstimate();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add car type rate selector, decoration costs, and travel inputs to booking form
- compute total estimate dynamically in client-side script
- document estimation requirements in text instructions

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_b_68b693fa275483318424b75eacdcbe25