### PR TITLE
Show full booking summary and detailed WhatsApp message

### DIFF
--- a/index.html
+++ b/index.html
@@ -840,8 +840,12 @@
                     <span class="summary-value" id="summaryService">Wedding</span>
                 </div>
                 <div class="summary-item">
-                    <span class="summary-label">Location:</span>
-                    <span class="summary-value" id="summaryLocation">Srinagar</span>
+                    <span class="summary-label">Start:</span>
+                    <span class="summary-value" id="summaryStart"></span>
+                </div>
+                <div class="summary-item">
+                    <span class="summary-label">End:</span>
+                    <span class="summary-value" id="summaryEnd"></span>
                 </div>
                 <div class="summary-item">
                     <span class="summary-label">Vehicle:</span>
@@ -858,6 +862,26 @@
                 <div class="summary-item">
                     <span class="summary-label">Phone:</span>
                     <span class="summary-value" id="summaryPhone">+917075196141</span>
+                </div>
+                <div class="summary-item">
+                    <span class="summary-label">Email:</span>
+                    <span class="summary-value" id="summaryEmail"></span>
+                </div>
+                <div class="summary-item">
+                    <span class="summary-label">Hours:</span>
+                    <span class="summary-value" id="summaryHours"></span>
+                </div>
+                <div class="summary-item">
+                    <span class="summary-label">Driving:</span>
+                    <span class="summary-value" id="summaryDriving"></span>
+                </div>
+                <div class="summary-item">
+                    <span class="summary-label">Decoration:</span>
+                    <span class="summary-value" id="summaryDecoration"></span>
+                </div>
+                <div class="summary-item">
+                    <span class="summary-label">Message:</span>
+                    <span class="summary-value" id="summaryMessage"></span>
                 </div>
             </div>
 
@@ -911,11 +935,12 @@
             const getVal = id => (document.getElementById(id)?.value || '').trim();
             
             // Enquiry type
-            const enquiryType = getVal('enquiryType');
-            
+            const enquiryType = document.querySelector('input[name="enquiryType"]:checked')?.value || 'Just Checking';
+
             // Required/common fields
             const fullName = getVal('name');
             const phone = getVal('phone');
+            const email = getVal('email');
             const eventDate = getVal('date');
             const service = getVal('serviceType');
             const vehicle = getVal('vehicle');
@@ -960,6 +985,7 @@
                 'Client',
                 `- Name: ${fullName}`,
                 `- Phone: +91${phone}`,
+                `- Email: ${email}`,
                 `- Enquiry Type: ${enquiryType}`
             ].join('\n');
             
@@ -967,11 +993,11 @@
                 'Event',
                 `- Date: ${eventDate}`,
                 `- Service: ${service}`,
-                `- Car: ${vehicle}`,
-                `- Start Location: ${startLocationStr}`,
-                `- End Location: ${endLocationStr}`,
-                `- Event Hours: ${eventHours || 'Not specified'}`,
-                `- Driving Option: ${drivingOption || 'Not specified'}`,
+                `- Vehicle: ${vehicle}`,
+                `- Start: ${startLocationStr}`,
+                `- End: ${endLocationStr}`,
+                `- Hours: ${eventHours || 'Not specified'}`,
+                `- Driving: ${(drivingOption === 'Other' && customDriving) ? customDriving : drivingOption || 'Not specified'}`,
                 message ? `- Special Requests: ${message}` : null
             ].filter(Boolean).join('\n');
             
@@ -1004,6 +1030,10 @@
             }
             if (!document.getElementById('phone')?.value.trim()) {
                 alert('Please enter your phone number.');
+                return;
+            }
+            if (!document.getElementById('email')?.value.trim()) {
+                alert('Please enter your email address.');
                 return;
             }
             if (!document.getElementById('date')?.value.trim()) {
@@ -1077,11 +1107,27 @@
             // Display booking summary
             document.getElementById('summaryEnquiry').textContent = enquiryType;
             document.getElementById('summaryService').textContent = serviceType;
-            document.getElementById('summaryLocation').textContent = startMainLocation;
+            const startParts = [];
+            if (startDetailedAddress) startParts.push(startDetailedAddress);
+            if (startMainLocation) startParts.push(startMainLocation);
+            if (startSubLocation) startParts.push(startSubLocation);
+            document.getElementById('summaryStart').textContent = startParts.join(' — ');
+            const endParts = [];
+            if (endDetailedAddress) endParts.push(endDetailedAddress);
+            if (endMainLocation) endParts.push(endMainLocation);
+            if (endSubLocation) endParts.push(endSubLocation);
+            document.getElementById('summaryEnd').textContent = endParts.join(' — ');
             document.getElementById('summaryVehicle').textContent = vehicle;
             document.getElementById('summaryDate').textContent = date;
             document.getElementById('summaryName').textContent = name;
-            document.getElementById('summaryPhone').textContent = `+917075196141`;
+            document.getElementById('summaryPhone').textContent = `+91${phone}`;
+            document.getElementById('summaryEmail').textContent = email;
+            document.getElementById('summaryHours').textContent = eventHours || 'Not specified';
+            const driveText = drivingOption === 'Other' && customDriving ? customDriving : drivingOption;
+            document.getElementById('summaryDriving').textContent = driveText || 'Not specified';
+            const decorText = wantDecoration === 'Yes' ? (decoration ? decoration : 'Yes') : 'No';
+            document.getElementById('summaryDecoration').textContent = decorText;
+            document.getElementById('summaryMessage').textContent = message || '—';
             document.getElementById('bookingSummary').style.display = 'block';
             
             // Open WhatsApp
@@ -1202,6 +1248,13 @@
                     customDrivingInput.classList.remove('show');
                     document.getElementById('customDriving').value = '';
                 }
+            });
+        });
+
+        // Service type selection - update hidden field
+        document.querySelectorAll('input[name="serviceTypeRadio"]').forEach(radio => {
+            radio.addEventListener('change', function() {
+                document.getElementById('serviceType').value = this.value;
             });
         });
 


### PR DESCRIPTION
## Summary
- Expand booking summary to show start and end locations, contact info, hours, driving option, decoration choice, and any message.
- Compose a cleaner WhatsApp message including email and detailed travel information, and validate email before sending.
- Sync service type radio buttons with hidden field for accurate message generation.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b82289bc2c8325bd01851218ec9857