### PR TITLE
Ensure booking form uses black background

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,6 +127,11 @@
             border: 1px solid rgba(255, 215, 0, 0.1);
         }
 
+        /* Ensure the form's outer area uses a black background */
+        #bookingForm {
+            background-color: #000;
+        }
+
         .section-title {
             font-size: 1.4rem;
             margin-bottom: 20px;


### PR DESCRIPTION
## Summary
- enforce black background for the booking form's outer area

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b91346f5388325823b5e624dc76bad