### PR TITLE
Sync package hour and distance presets with form inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,4 @@ See [car_pricing_list.md](car_pricing_list.md) for current vehicle pricing.
 ### Estimate Rules
 
 - Base vehicle price comes from the selected model.
-- Each kilometer adds INR 100 to the total.
-- For bookings longer than 8 hours, every extra hour costs an additional 4% of the vehicle price.
+- Package includes 20 km and 10 hours. Beyond these limits, INR 100 is added for every extra 2 km and each additional hour costs 4% of the vehicle price.

--- a/estimate_form_instructions.txt
+++ b/estimate_form_instructions.txt
@@ -13,15 +13,16 @@ Estimate Form Implementation Instructions
 
 3. Travel distance calculation:
    - Input total distance in kilometers.
-   - Each kilometer adds INR 30 to the estimate.
+   - Pricing includes 20 km. Beyond this, INR 100 is added for every extra 2 km.
+   - Provide preset distance buttons (20 km base, 30 km, 40 km, 50 km, 60 km) that auto-fill the travel distance field but allow manual edits.
 
 4. Hourly cost for duration:
    - Input total booking duration in hours.
-   - Base rate: INR 800 for up to 8 hours.
-   - Additional INR 100 for each hour beyond 8.
+   - Provide preset hour buttons (10 hours included, 12 hours, 15 hours, 1 Day, 2 Days) that auto-fill the booking duration field but allow manual edits.
+   - Base package covers 10 hours. Each additional hour adds 4% of the vehicle price.
 
 5. Estimate calculation:
-   - Total = Car Rate + Decoration Cost + (Distance × 30) + Hourly Charges.
+   - Total = Car Rate + Decoration Cost + Distance Charges + Hourly Charges.
    - Update and display the total in real time as inputs change.
 
 6. Display the estimate on the form for user review before submission.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Valley Wedding Cars - Luxury Fleet Booking</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <style>
@@ -89,10 +88,6 @@
             filter: none;
         }
 
-        /* Responsive tweak for small screens */
-        @media (max-width: 420px) {
-            .logo-wrap { --size: 84px; }
-        }
 
         .title {
             font-size: 2.2rem;
@@ -434,6 +429,35 @@
             border-color: #d4af37;
         }
 
+        .distance-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .distance-option {
+            flex: 1;
+            min-width: 120px;
+            text-align: center;
+            padding: 10px;
+            background: rgba(255, 215, 0, 0.1);
+            border-radius: 8px;
+            cursor: pointer;
+            border: 1px solid rgba(255, 215, 0, 0.3);
+            transition: all 0.2s ease;
+        }
+
+        .distance-option:hover {
+            background: rgba(255, 215, 0, 0.2);
+        }
+
+        .distance-option.selected {
+            background: #d4af37;
+            color: #000;
+            border-color: #d4af37;
+        }
+
         .driving-options {
             display: flex;
             flex-wrap: wrap;
@@ -481,67 +505,35 @@
             display: block;
         }
 
-        @media (min-width: 768px) {
-            .container {
-                max-width: 1200px;
-            }
-
-            #bookingForm {
-                display: grid;
-                grid-template-columns: repeat(2, 1fr);
-                gap: 20px;
-            }
-
-            #bookingForm .form-section {
-                margin-bottom: 20px;
-            }
-
-            #bookingForm button,
-            #bookingForm .booking-summary,
-            #bookingForm .vehicle-selection,
-            #bookingForm .full-width {
-                grid-column: 1 / -1;
-            }
-
-            #bookingForm .service-section {
-                grid-column: 1;
-                grid-row: 2;
-            }
-
-            #bookingForm .location-section {
-                grid-column: 2;
-                grid-row: 2;
-            }
+        .container {
+            max-width: 1200px;
         }
 
-        @media (max-width: 600px) {
-            .container {
-                padding: 15px;
-            }
+        #bookingForm {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 20px;
+        }
 
-            .title {
-                font-size: 1.8rem;
-            }
+        #bookingForm .form-section {
+            margin-bottom: 20px;
+        }
 
-            .quote {
-                font-size: 1rem;
-            }
+        #bookingForm button,
+        #bookingForm .booking-summary,
+        #bookingForm .vehicle-selection,
+        #bookingForm .full-width {
+            grid-column: 1 / -1;
+        }
 
-            .location-wrapper {
-                flex-direction: column;
-            }
+        #bookingForm .service-section {
+            grid-column: 1;
+            grid-row: 2;
+        }
 
-            .location-group {
-                flex-direction: column;
-            }
-
-            .location-grid {
-                grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-            }
-
-            .form-section {
-                padding: 15px;
-            }
+        #bookingForm .location-section {
+            grid-column: 2;
+            grid-row: 2;
         }
     </style>
 </head>
@@ -767,14 +759,24 @@
                 <div class="form-group">
                     <label for="eventHours">Event Hours:</label>
                     <div class="hours-container" id="hoursContainer">
-                        <div class="hour-option" data-hours="8">8 Hours</div>
-                        <div class="hour-option" data-hours="10">10 Hours</div>
+                        <div class="hour-option selected" data-hours="10">10 Hours (Included)</div>
                         <div class="hour-option" data-hours="12">12 Hours</div>
                         <div class="hour-option" data-hours="15">15 Hours</div>
                         <div class="hour-option" data-hours="24">1 Day</div>
                         <div class="hour-option" data-hours="48">2 Days</div>
                     </div>
-                    <input type="hidden" id="eventHours" name="eventHours" value="">
+                    <input type="hidden" id="eventHours" name="eventHours" value="10">
+                </div>
+                <div class="form-group">
+                    <label for="eventDistance">Event Total Distance:</label>
+                    <div class="distance-container" id="distanceContainer">
+                        <div class="distance-option selected" data-distance="20">20 KM (Included)</div>
+                        <div class="distance-option" data-distance="30">30 KM</div>
+                        <div class="distance-option" data-distance="40">40 KM</div>
+                        <div class="distance-option" data-distance="50">50 KM</div>
+                        <div class="distance-option" data-distance="60">60 KM</div>
+                    </div>
+                    <input type="hidden" id="eventDistance" name="eventDistance" value="20">
                 </div>
             </div>
 
@@ -782,15 +784,15 @@
                 <h2 class="section-title"><i class="fas fa-route"></i> Travel Details</h2>
                 <div class="form-group">
                     <label for="distance">Travel Distance (km):</label>
-                    <input type="number" id="distance" name="distance" min="0" placeholder="Enter distance">
+                    <input type="number" id="distance" name="distance" min="0" placeholder="Enter distance" value="20">
                 </div>
                 <div class="form-group">
                     <label for="duration">Booking Duration (hours):</label>
-                    <input type="number" id="duration" name="duration" min="0" placeholder="Enter total hours">
+                    <input type="number" id="duration" name="duration" min="0" placeholder="Enter total hours" value="10">
                 </div>
                 <div class="estimate-output">
                     <strong>Total Estimate: INR <span id="totalEstimate">0</span></strong>
-                    <p class="estimate-note">*Pricing may vary with fuel MRP and booking hours. Please verify the final estimate with our team via WhatsApp or call.</p>
+                    <p class="estimate-note" id="estimateNote">*Pricing includes 20 km and 10 hours. Price increases when these package limits are exceeded. Final estimate may vary with fuel MRP. Please verify with our team via WhatsApp or call.</p>
                 </div>
             </div>
 
@@ -965,6 +967,7 @@
             const endSubLocation = getVal('endSubLocation');
             const endDetailedAddress = getVal('endDetailedAddress');
             const eventHours = getVal('eventHours');
+            const eventDistance = getVal('eventDistance');
             const drivingOption = getVal('drivingOption');
             const customDriving = getVal('customDriving');
             const message = getVal('message');
@@ -1012,6 +1015,7 @@
                 `- Start: ${startLocationStr}`,
                 `- End: ${endLocationStr}`,
                 `- Hours: ${eventHours || 'Not specified'}`,
+                `- Distance Package: ${eventDistance || 'Not specified'}`,
                 `- Driving: ${(drivingOption === 'Other' && customDriving) ? customDriving : drivingOption || 'Not specified'}`,
                 message ? `- Special Requests: ${message}` : null
             ].filter(Boolean).join('\n');
@@ -1232,14 +1236,48 @@
                 document.querySelectorAll('.hour-option').forEach(opt => {
                     opt.classList.remove('selected');
                 });
-                
+
                 // Add selected class to clicked option
                 this.classList.add('selected');
-                
-                // Set hidden input value
+
+                // Set hidden input and sync duration input
                 document.getElementById('eventHours').value = this.dataset.hours;
+                const durationInput = document.getElementById('duration');
+                if (durationInput) durationInput.value = this.dataset.hours;
+                calculateEstimate();
             });
         });
+
+        // Event distance selection
+        document.querySelectorAll('.distance-option').forEach(option => {
+            option.addEventListener('click', function() {
+                document.querySelectorAll('.distance-option').forEach(opt => {
+                    opt.classList.remove('selected');
+                });
+
+                this.classList.add('selected');
+                document.getElementById('eventDistance').value = this.dataset.distance;
+                const distanceInput = document.getElementById('distance');
+                if (distanceInput) distanceInput.value = this.dataset.distance;
+                calculateEstimate();
+            });
+        });
+
+        const distanceInputEl = document.getElementById('distance');
+        if (distanceInputEl) {
+            distanceInputEl.addEventListener('input', function() {
+                document.getElementById('eventDistance').value = this.value;
+                calculateEstimate();
+            });
+        }
+
+        const durationInputEl = document.getElementById('duration');
+        if (durationInputEl) {
+            durationInputEl.addEventListener('input', function() {
+                document.getElementById('eventHours').value = this.value;
+                calculateEstimate();
+            });
+        }
 
         // Driving options selection
         document.querySelectorAll('.driving-option').forEach(option => {
@@ -1327,13 +1365,17 @@
                 decorationCost = DECORATION_COSTS[decoType] || 0;
             }
 
+            const baseDistance = 20;
             const distance = parseFloat(document.getElementById('distance')?.value) || 0;
-            const distanceCost = distance * 100;
+            let distanceCost = 0;
+            if (distance > baseDistance) {
+                distanceCost = Math.ceil((distance - baseDistance) / 2) * 100;
+            }
 
             const duration = parseFloat(document.getElementById('duration')?.value) || 0;
             let hourlyCost = 0;
-            if (duration > 8) {
-                hourlyCost = (duration - 8) * carRate * 0.04;
+            if (duration > 10) {
+                hourlyCost = (duration - 10) * carRate * 0.04;
             }
 
             const total = carRate + decorationCost + distanceCost + hourlyCost;
@@ -1341,14 +1383,23 @@
             if (estimateEl) {
                 estimateEl.textContent = total;
             }
+
+            const noteEl = document.getElementById('estimateNote');
+            if (noteEl) {
+                let note = '*Pricing includes 20 km and 10 hours.';
+                const reasons = [];
+                if (distance > baseDistance) reasons.push('extra distance');
+                if (duration > 10) reasons.push('extra time');
+                if (reasons.length) {
+                    note += ' Additional charges added for ' + reasons.join(' and ') + '.';
+                }
+                note += ' Final estimate may vary with fuel MRP. Please verify with our team via WhatsApp or call.';
+                noteEl.textContent = note;
+            }
         }
 
         const vehicleEl = document.getElementById('vehicle');
         if (vehicleEl) vehicleEl.addEventListener('change', calculateEstimate);
-        ['distance', 'duration'].forEach(id => {
-            const el = document.getElementById(id);
-            if (el) el.addEventListener('input', calculateEstimate);
-        });
         calculateEstimate();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- mark 10-hour and 20 km buttons as included in package and add presets up to 60 km
- auto-fill Booking Duration and Travel Distance fields from selected presets while keeping them editable
- explain extra charges in Travel Details note and update docs for package limits
- drop mobile-specific styling so the desktop layout displays consistently on phones

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bc1dd875b08331b825eba362195315