### PR TITLE
feat: add car images with full view option

### DIFF
--- a/index.html
+++ b/index.html
@@ -501,6 +501,10 @@
             border: 2px solid #d4af37;
         }
 
+        #fullViewButton {
+            margin-top: 10px;
+        }
+
         .booking-summary {
             background: rgba(255, 215, 0, 0.08);
             padding: 20px;
@@ -757,17 +761,14 @@
                     <label for="vehicle">Select Your Vehicle:</label>
                     <select id="vehicle" name="vehicle" required>
                         <option value="">Choose a vehicle...</option>
-                        <option value="AUDI A6">AUDI A6 - INR 16000</option>
-                        <option value="BMW 5 Series F10 (Old Shape)">BMW 5 Series F10 (Old Shape) - Price TBD</option>
-                        <option value="BMW 5 Series G30">BMW 5 Series G30 - Price TBD</option>
-                        <option value="BMW Convertible">BMW Convertible - INR 26000</option>
-                        <option value="Hyundai Creta">Hyundai Creta - INR 12000</option>
-                        <option value="Hyundai Verna">Hyundai Verna - INR 12000</option>
-                        <option value="Mercedes CLA 200">Mercedes CLA 200 - INR 14000</option>
-                        <option value="Mercedes G Wagon">Mercedes G Wagon - INR 160000</option>
-                        <option value="Mercedes S Class">Mercedes S Class - INR 22000</option>
-                        <option value="Range Rover Sport">Range Rover Sport - INR 85000</option>
-                        <option value="Range Rover Sport 2">Range Rover Sport 2 - INR 125000</option>
+                        <option value="AUDI A6">AUDI A6</option>
+                        <option value="BMW 330 D Convertible">BMW 330 D Convertible</option>
+                        <option value="BMW 5 Series F10 (Old Shape)">BMW 5 Series F10 (Old Shape)</option>
+                        <option value="BMW 5 SERIES G30 (New Shape)">BMW 5 SERIES G30 (New Shape)</option>
+                        <option value="Mercedes G-Wagon">Mercedes G-Wagon</option>
+                        <option value="MERCEDES Maybach">MERCEDES Maybach</option>
+                        <option value="MERCEDES S-CLASS S350">MERCEDES S-CLASS S350</option>
+                        <option value="Range Rover Sport">Range Rover Sport</option>
                     </select>
                 </div>
 
@@ -802,7 +803,8 @@
             </div>
 
             <div class="car-image-container" id="carImageContainer">
-                <img id="carImage" class="car-image" src="#" alt="Selected Car">
+                <img id="carImage" class="car-image" src="" alt="Car Image">
+                <button id="fullViewButton" class="btn" style="display:none;" onclick="window.open(document.getElementById('carImage').src, '_blank')">Full View</button>
             </div>
 
             <div class="form-section driving-section full-width">
@@ -893,11 +895,14 @@
 
         // Car images mapping
         const CAR_IMAGES = {
-            "BMW 5 SERIES G30": "https://cdn.jsdelivr.net/gh/free-whiteboard-online/Free-Erasorio-Alternative-for-Collaborative-Design@aa33fd78421e1a8fa9e1ff6d95800fc75c5c61b1/uploads/2025-08-22T09-42-16-425Z-k1kxvaegs.jpg",
-            "BMW 5 Series F10 (Old Shape)": "https://cdn.jsdelivr.net/gh/free-whiteboard-online/Free-Erasorio-Alternative-for-Collaborative-Design@7766519b7d48ee97144293d33bd1abcaa1dc7537/uploads/2025-08-22T09-43-49-237Z-bl0h1uu6i.jpg",
-            "Range Rover Sport": "https://cdn.jsdelivr.net/gh/free-whiteboard-online/Free-Erasorio-Alternative-for-Collaborative-Design@7651fdcb4d348df3e803de2255e8f0b5a1821dc9/uploads/2025-08-22T09-44-23-132Z-uxngpxuq2.jpg",
-            "Mercedes G Wagon": "https://cdn.jsdelivr.net/gh/free-whiteboard-online/Free-Erasorio-Alternative-for-Collaborative-Design@ef38be0a76189d47ee79a3a182c2c16979e8d014/uploads/2025-08-22T09-45-09-584Z-uowaboqrx.jpg",
-            "AUDI A6": "https://cdn.jsdelivr.net/gh/free-whiteboard-online/Free-Erasorio-Alternative-for-Collaborative-Design@a47d1cecb04bbd648bc7a22ff99f74a78bee551c/uploads/2025-08-22T09-45-58-518Z-z518bw92t.jpg"
+            "AUDI A6": "https://i.postimg.cc/zfxy8jD7/AUDI-A6.jpg",
+            "BMW 330 D Convertible": "https://i.postimg.cc/L4nyP974/BMW-330-D-Convertible.jpg",
+            "BMW 5 Series F10 (Old Shape)": "https://i.postimg.cc/zvgvwYC2/BMW-5-Series-F10-OLD-SHAPE.jpg",
+            "BMW 5 SERIES G30 (New Shape)": "https://i.postimg.cc/Hj1xBv3Y/BMW-5-SERIES-G30-New-shape.jpg",
+            "Mercedes G-Wagon": "https://i.postimg.cc/J7vp5wVN/Mercedes-G-wagon.jpg",
+            "MERCEDES Maybach": "https://i.postimg.cc/MKBdssqh/MERCEDES-Maybach.jpg",
+            "MERCEDES S-CLASS S350": "https://i.postimg.cc/cLNTPQJ6/MERCEDES-S-CLASS-S350.jpg",
+            "Range Rover Sport": "https://i.postimg.cc/rwCgTKdj/Range-Rover-Sport.jpg"
         };
 
         // WhatsApp message builder function
@@ -1087,6 +1092,7 @@
             
             // Hide car image
             document.getElementById('carImageContainer').classList.remove('show');
+            document.getElementById('fullViewButton').style.display = 'none';
             // Hide self-drive note
             document.getElementById('selfDriveNote').style.display = 'none';
             document.querySelectorAll('.driving-option').forEach(opt => opt.classList.remove('selected'));
@@ -1097,18 +1103,25 @@
         const today = new Date().toISOString().split('T')[0];
         document.getElementById('date').min = today;
 
-        // Car selection with image display
-        document.getElementById('vehicle').addEventListener('change', function() {
+        // Car selection with image display and full view option
+        document.getElementById('vehicle').addEventListener('change', updateCarImage);
+
+        function updateCarImage() {
+            const carSelect = document.getElementById('vehicle');
             const carImageContainer = document.getElementById('carImageContainer');
             const carImage = document.getElementById('carImage');
-            
-            if (this.value && CAR_IMAGES[this.value]) {
-                carImage.src = CAR_IMAGES[this.value];
+            const fullViewButton = document.getElementById('fullViewButton');
+
+            if (carSelect.value && CAR_IMAGES[carSelect.value]) {
+                carImage.src = CAR_IMAGES[carSelect.value];
                 carImageContainer.classList.add('show');
+                fullViewButton.style.display = 'inline';
             } else {
+                carImage.src = '';
                 carImageContainer.classList.remove('show');
+                fullViewButton.style.display = 'none';
             }
-        });
+        }
 
         // Driving options selection with self-drive note
         document.querySelectorAll('.driving-option').forEach(option => {


### PR DESCRIPTION
## Summary
- simplify vehicle dropdown to display only car names
- show selected car image with a Full View button opening a new tab
- map car selections to image URLs and toggle Full View visibility via JavaScript

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c164383dac8331a536effe29e56c4c