### PR TITLE
Add BMW 520D to vehicle list

### DIFF
--- a/car_pricing_list.md
+++ b/car_pricing_list.md
@@ -5,6 +5,7 @@
 | AUDI A6 | 16000 |
 | BMW 5 Series F10 (Old Shape) | TBD |
 | BMW 5 Series G30 | TBD |
+| BMW 520D | TBD |
 | BMW Convertible | 26000 |
 | Hyundai Creta | 12000 |
 | Hyundai Verna | 12000 |

--- a/index.html
+++ b/index.html
@@ -764,6 +764,7 @@
                         <option value="AUDI A6">AUDI A6</option>
                         <option value="BMW 330 D Convertible">BMW 330 D Convertible</option>
                         <option value="BMW 5 Series F10 (Old Shape)">BMW 5 Series F10 (Old Shape)</option>
+                        <option value="BMW 520D">BMW 520D</option>
                         <option value="BMW 5 SERIES G30 (New Shape)">BMW 5 SERIES G30 (New Shape)</option>
                         <option value="Mercedes G-Wagon">Mercedes G-Wagon</option>
                         <option value="MERCEDES Maybach">MERCEDES Maybach</option>
@@ -907,6 +908,7 @@
             "AUDI A6": "https://i.postimg.cc/zfxy8jD7/AUDI-A6.jpg",
             "BMW 330 D Convertible": "https://i.postimg.cc/L4nyP974/BMW-330-D-Convertible.jpg",
             "BMW 5 Series F10 (Old Shape)": "https://i.postimg.cc/zvgvwYC2/BMW-5-Series-F10-OLD-SHAPE.jpg",
+            "BMW 520D": "https://i.postimg.cc/26dwqh2j/BMW-520D.jpg",
             "BMW 5 SERIES G30 (New Shape)": "https://i.postimg.cc/Hj1xBv3Y/BMW-5-SERIES-G30-New-shape.jpg",
             "Mercedes G-Wagon": "https://i.postimg.cc/J7vp5wVN/Mercedes-G-wagon.jpg",
             "MERCEDES Maybach": "https://i.postimg.cc/MKBdssqh/MERCEDES-Maybach.jpg",


### PR DESCRIPTION
## Summary
- add the BMW 520D to the booking vehicle selector with its hosted image
- document the BMW 520D entry in the car pricing list for visibility

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d2314d206c83298765adc6e46cee6c