### PR TITLE
Update WhatsApp number to +918826139339

### DIFF
--- a/index.html
+++ b/index.html
@@ -865,7 +865,7 @@
                 </div>
                 <div class="summary-item">
                     <span class="summary-label">Phone:</span>
-                    <span class="summary-value" id="summaryPhone">+917075196141</span>
+                    <span class="summary-value" id="summaryPhone">+918826139339</span>
                 </div>
                 <div class="summary-item">
                     <span class="summary-label">Email:</span>
@@ -1022,7 +1022,7 @@
             }
             
             const msg = buildBookingMessage();
-            const phoneIntl = '917075196141'; // Updated WhatsApp number
+            const phoneIntl = '918826139339'; // Updated WhatsApp number
             const url = `https://wa.me/${phoneIntl}?text=${encodeURIComponent(msg)}`;
             window.open(url, '_blank', 'noopener,noreferrer');
         }


### PR DESCRIPTION
## Summary
- update the default booking summary to display the new WhatsApp number
- point the WhatsApp chat link to +918826139339 in international format

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68d2354738ec8329b2d8887859ff7eac